### PR TITLE
Add configurable ranking parameters

### DIFF
--- a/app/output_formatter.py
+++ b/app/output_formatter.py
@@ -7,7 +7,7 @@ def format_output(input_documents, persona, job, ranked_sections, refined_snippe
             "processing_timestamp": timestamp
         },
         "extracted_sections": [],
-        "sub_section_analysis": []
+        "subsection_analysis": []
     }
 
     for sec in ranked_sections:
@@ -19,9 +19,8 @@ def format_output(input_documents, persona, job, ranked_sections, refined_snippe
         })
 
     for ref in refined_snippets:
-        output["sub_section_analysis"].append({
+        output["subsection_analysis"].append({
             "document": ref["document"],
-            "section_title": ref["section_title"],
             "refined_text": ref["refined_text"],
             "page_number": ref["page_number"]
         })


### PR DESCRIPTION
## Summary
- allow configuring the number of ranked sections and refined snippets
- remove extra metadata fields to match sample output
- switch to `subsection_analysis` key and omit section titles in snippet results

## Testing
- `python -m py_compile app/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887960027ac83289cc2b9e01bb977ed